### PR TITLE
Combine chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Application Options:
   -m, --mac-os-version= Version of Mac OS, e.g. '10.15', from which the Messages chat database file was copied (not needed if bagoup is running on the same Mac)
   -c, --contacts-path=  Path to the contacts vCard file
   -s, --self-handle=    Prefix to use for for messages sent by you (default: Me)
+      --separate-chats  Do not merge chats with the same contact into a single file, e.g. iMessage and SMS
 
 Help Options:
   -h, --help            Show this help message

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See https://github.com/tagatac/bagoup/tree/master/example-export for an example
 export directory structure.
 
 ## Author
-Copyright (C) 2020-2021 [David Tagatac](mailto:david@tagatac.net)
+Copyright (C) 2020-2022 [David Tagatac](mailto:david@tagatac.net)
 
 [ci-img]: https://travis-ci.com/tagatac/bagoup.svg?branch=master
 [ci]: https://app.travis-ci.com/github/tagatac/bagoup

--- a/chatdb/chatdb.go
+++ b/chatdb/chatdb.go
@@ -12,6 +12,7 @@ package chatdb
 import (
 	"database/sql"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/Masterminds/semver"
@@ -146,6 +147,7 @@ func (d chatDB) GetChats(contactMap map[string]*vcard.Card) ([]EntityChats, erro
 	for _, entityChats := range addressChats {
 		chats = append(chats, entityChats)
 	}
+	sort.SliceStable(chats, func(i, j int) bool { return chats[i].Name < chats[j].Name })
 	return chats, nil
 }
 

--- a/chatdb/chatdb.go
+++ b/chatdb/chatdb.go
@@ -134,7 +134,7 @@ func (d chatDB) GetChats(contactMap map[string]*vcard.Card) ([]EntityChats, erro
 			ID:   id,
 			GUID: guid,
 		}
-		if card, ok := contactMap[displayName]; ok {
+		if card, ok := contactMap[name]; ok {
 			addContactChat(card, displayName, chat, contactChats)
 		} else {
 			addAddressChat(name, displayName, chat, addressChats)

--- a/chatdb/chatdb.go
+++ b/chatdb/chatdb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 David Tagatac <david@tagatac.net>
+// Copyright (C) 2020-2022 David Tagatac <david@tagatac.net>
 // See main.go for usage terms.
 
 // Package chatdb provides an interface ChatDB for interacting with the Mac OS

--- a/chatdb/chatdb_test.go
+++ b/chatdb/chatdb_test.go
@@ -158,8 +158,8 @@ func TestGetChats(t *testing.T) {
 			setupQuery: func(query *sqlmock.ExpectedQuery) {
 				rows := sqlmock.NewRows([]string{"ROWID", "guid", "chat_identifier", "display_name"}).
 					AddRow(1, "testguid1", "testchatname1", "testdisplayname1").
-					AddRow(2, "testguid2", "testchatname2", "").
-					AddRow(3, "testguid3", "testchatname2", "")
+					AddRow(2, "testguid2", "testchatname2", "testdisplayname2").
+					AddRow(3, "testguid3", "testchatname2", "testdisplayname2")
 				query.WillReturnRows(rows)
 			},
 			wantChats: []EntityChats{

--- a/chatdb/chatdb_test.go
+++ b/chatdb/chatdb_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 David Tagatac <david@tagatac.net>
+// Copyright (C) 2020-2022 David Tagatac <david@tagatac.net>
 // See main.go for usage terms.
 
 package chatdb

--- a/chatdb/chatdb_test.go
+++ b/chatdb/chatdb_test.go
@@ -109,7 +109,7 @@ func TestGetChats(t *testing.T) {
 		msg        string
 		contactMap map[string]*vcard.Card
 		setupQuery func(*sqlmock.ExpectedQuery)
-		wantChats  []Chat
+		wantChats  []EntityChats
 		wantErr    string
 	}{
 		{
@@ -117,19 +117,32 @@ func TestGetChats(t *testing.T) {
 			setupQuery: func(query *sqlmock.ExpectedQuery) {
 				rows := sqlmock.NewRows([]string{"ROWID", "guid", "chat_identifier", "display_name"}).
 					AddRow(1, "testguid1", "testchatname1", "testdisplayname1").
-					AddRow(2, "testguid2", "testchatname2", "")
+					AddRow(2, "testguid2", "testchatname2", "").
+					AddRow(3, "testguid3", "testchatname2", "")
 				query.WillReturnRows(rows)
 			},
-			wantChats: []Chat{
+			wantChats: []EntityChats{
 				{
-					ID:          1,
-					GUID:        "testguid1",
-					DisplayName: "testdisplayname1",
+					Name: "testchatname2",
+					Chats: []Chat{
+						{
+							ID:   2,
+							GUID: "testguid2",
+						},
+						{
+							ID:   3,
+							GUID: "testguid3",
+						},
+					},
 				},
 				{
-					ID:          2,
-					GUID:        "testguid2",
-					DisplayName: "testchatname2",
+					Name: "testdisplayname1",
+					Chats: []Chat{
+						{
+							ID:   1,
+							GUID: "testguid1",
+						},
+					},
 				},
 			},
 		},
@@ -145,19 +158,32 @@ func TestGetChats(t *testing.T) {
 			setupQuery: func(query *sqlmock.ExpectedQuery) {
 				rows := sqlmock.NewRows([]string{"ROWID", "guid", "chat_identifier", "display_name"}).
 					AddRow(1, "testguid1", "testchatname1", "testdisplayname1").
-					AddRow(2, "testguid2", "testchatname2", "")
+					AddRow(2, "testguid2", "testchatname2", "").
+					AddRow(3, "testguid3", "testchatname2", "")
 				query.WillReturnRows(rows)
 			},
-			wantChats: []Chat{
+			wantChats: []EntityChats{
 				{
-					ID:          1,
-					GUID:        "testguid1",
-					DisplayName: "testdisplayname1",
+					Name: "Contactgiven Contactsurname",
+					Chats: []Chat{
+						{
+							ID:   2,
+							GUID: "testguid2",
+						},
+						{
+							ID:   3,
+							GUID: "testguid3",
+						},
+					},
 				},
 				{
-					ID:          2,
-					GUID:        "testguid2",
-					DisplayName: "Contactgiven Contactsurname",
+					Name: "testdisplayname1",
+					Chats: []Chat{
+						{
+							ID:   1,
+							GUID: "testguid1",
+						},
+					},
 				},
 			},
 		},
@@ -218,19 +244,6 @@ func TestGetMessageIDs(t *testing.T) {
 			wantIDs: []DatedMessageID{
 				{192, 593720716},
 				{168, 601412272},
-			},
-		},
-		{
-			msg: "success reorder",
-			setupQuery: func(query *sqlmock.ExpectedQuery) {
-				rows := sqlmock.NewRows([]string{"message_id", "message_date"}).
-					AddRow(192, 601412272).
-					AddRow(168, 593720716622331392)
-				query.WillReturnRows(rows)
-			},
-			wantIDs: []DatedMessageID{
-				{168, 593720716},
-				{192, 601412272},
 			},
 		},
 		{

--- a/chatdb/mock_chatdb/mock_chatdb.go
+++ b/chatdb/mock_chatdb/mock_chatdb.go
@@ -37,10 +37,10 @@ func (m *MockChatDB) EXPECT() *MockChatDBMockRecorder {
 }
 
 // GetChats mocks base method.
-func (m *MockChatDB) GetChats(arg0 map[string]*vcard.Card) ([]chatdb.Chat, error) {
+func (m *MockChatDB) GetChats(arg0 map[string]*vcard.Card) ([]chatdb.EntityChats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChats", arg0)
-	ret0, _ := ret[0].([]chatdb.Chat)
+	ret0, _ := ret[0].([]chatdb.EntityChats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        target: 72%
+        threshold: 0%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,3 @@
-codecov:
-  branch: main
-
 coverage:
   status:
-    project:
-      default:
-        target: 72%
-        threshold: 0.5%
+    patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ coverage:
     project:
       default:
         target: 72%
-        threshold: 0%
+        threshold: 0.5%

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 // bagoup - An export utility for Mac OS Messages.
-// Copyright (C) 2020 David Tagatac <david@tagatac.net>
+// Copyright (C) 2020-2022 David Tagatac <david@tagatac.net>
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published

--- a/main_test.go
+++ b/main_test.go
@@ -376,6 +376,32 @@ func TestExportChats(t *testing.T) {
 			wantErr: "create directory \"backup/testdisplayname\": operation not permitted",
 		},
 		{
+			msg: "directory creation error - with chat merge",
+			setupMock: func(dbMock *mock_chatdb.MockChatDB) {
+				dbMock.EXPECT().GetChats(nil).Return([]chatdb.EntityChats{
+					{
+						Name: "testdisplayname",
+						Chats: []chatdb.Chat{
+							{
+								ID:   1,
+								GUID: "testguid",
+							},
+						},
+					},
+				}, nil)
+				dbMock.EXPECT().GetMessageIDs(1).Return(
+					[]chatdb.DatedMessageID{
+						{ID: 100, Date: 0},
+						{ID: 200, Date: 0},
+					},
+					nil,
+				)
+			},
+			roFs:       true,
+			mergeChats: true,
+			wantErr:    "create directory \"backup/testdisplayname\": operation not permitted",
+		},
+		{
 			msg: "GetMessageIDs error",
 			setupMock: func(dbMock *mock_chatdb.MockChatDB) {
 				dbMock.EXPECT().GetChats(nil).Return([]chatdb.EntityChats{

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 David Tagatac <david@tagatac.net>
+// Copyright (C) 2020-2022 David Tagatac <david@tagatac.net>
 // See main.go for usage terms.
 
 package main


### PR DESCRIPTION
Combine chats for the same entity by default. We can know that multiple chats are the same entity in two ways:
1. they both match to the same contact card, or
2. they have the same chat_identifier (phone number or email address).

Also add a flag to allow users to opt out of this default behavior.

Closes #8 