### PR TITLE
Truncate chat filename if it will exceed 255 characters

### DIFF
--- a/internal/bagoup/write.go
+++ b/internal/bagoup/write.go
@@ -16,12 +16,17 @@ import (
 	"github.com/tagatac/bagoup/opsys/pdfgen"
 )
 
+const _filenamePrefixMaxLength = 251
+
 func (cfg *configuration) writeFile(entityName string, guids []string, messageIDs []chatdb.DatedMessageID) error {
 	chatDirPath := strings.TrimRight(filepath.Join(cfg.Options.ExportPath, entityName), ". ")
 	if err := cfg.OS.MkdirAll(chatDirPath, os.ModePerm); err != nil {
 		return errors.Wrapf(err, "create directory %q", chatDirPath)
 	}
 	filename := strings.Join(guids, ";;;")
+	if len(filename) > _filenamePrefixMaxLength {
+		filename = filename[:_filenamePrefixMaxLength-1]
+	}
 	chatPath := filepath.Join(chatDirPath, filename)
 	var outFile opsys.OutFile
 	if cfg.Options.OutputPDF {

--- a/internal/bagoup/write_test.go
+++ b/internal/bagoup/write_test.go
@@ -502,4 +502,25 @@ func TestWriteFile(t *testing.T) {
 			assert.Equal(t, tt.wantConvFail, cfg.counts.conversionsFailed)
 		})
 	}
+
+	t.Run("long email address", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		osMock := mock_opsys.NewMockOS(ctrl)
+		ofMock := mock_opsys.NewMockOutFile(ctrl)
+		gomock.InOrder(
+			osMock.EXPECT().MkdirAll("friend", os.ModePerm),
+			osMock.EXPECT().Create("friend/iMessage;-;heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress@gmail.c.txt").Return(chatFile, nil),
+			osMock.EXPECT().NewTxtOutFile(chatFile).Return(ofMock),
+			ofMock.EXPECT().Flush(),
+			osMock.EXPECT().GetOpenFilesLimit().Return(256),
+		)
+
+		cfg := configuration{OS: osMock}
+		cfg.writeFile(
+			"friend",
+			[]string{"iMessage;-;heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress.heresareallylongemailaddress@gmail.com"},
+			nil,
+		)
+	})
 }


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**: Chat files names are created by joining all of the email addresses and/or phone numbers used to message the given contact. These file names are now limited to 255 characters, including the file type suffixes.

**Why this change is being made**: Most filesystems do not support filenames longer than 255 characters: https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits

**Related issue(s)**: Fixes #32 

**Follow-up changes needed**: Possibly address file path length limits.

**Is the change completely covered by unit tests? If not, why not?**: Yes.
