### PR TITLE
Decode text from the attributedBody column

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ $ cat "messages-export/Novak Djokovic/iMessage;-;+3815555555555.txt"
 ### PDF (--pdf flag)
 ![Example PDF Export](example-exports/example-pdf-screenshot.png)
 ## Dependencies
+- [python-typedstream](https://github.com/dgelessus/python-typedstream) (for compatibility with Messages on Mac OS 13 and newer)
+```
+git clone git@github.com:dgelessus/python-typedstream.git
+cd python-typedstream
+python3 -m pip install .
+```
 - [wkhtmltopdf](https://wkhtmltopdf.org/) (for exporting to PDF; not needed for exports to plaintext)
 ```
 brew install wkhtmltopdf

--- a/cmd/bagoup/main.go
+++ b/cmd/bagoup/main.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -58,7 +57,7 @@ func main() {
 	logFatalOnErr(errors.Wrap(err, "create pathtools"))
 	opts.DBPath = ptools.ReplaceTilde(opts.DBPath)
 
-	s, err := opsys.NewOS(afero.NewOsFs(), os.Stat, exec.Command, scall.NewSyscall())
+	s, err := opsys.NewOS(afero.NewOsFs(), os.Stat, scall.NewSyscall())
 	logFatalOnErr(errors.Wrap(err, "instantiate OS"))
 	db, err := sql.Open("sqlite3", opts.DBPath)
 	logFatalOnErr(errors.Wrapf(err, "open DB file %q", opts.DBPath))

--- a/example-exports/examplegen.go
+++ b/example-exports/examplegen.go
@@ -3,7 +3,6 @@ package main
 import (
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -37,7 +36,7 @@ func main() {
 		{isPDF: false, exportPath: "messages-export"},
 		{isPDF: true, exportPath: "messages-export-pdf"},
 	}
-	s, err := opsys.NewOS(afero.NewOsFs(), os.Stat, exec.Command, scall.NewSyscall())
+	s, err := opsys.NewOS(afero.NewOsFs(), os.Stat, scall.NewSyscall())
 	if err != nil {
 		log.Panic(errors.Wrap(err, "instantiate OS"))
 	}

--- a/exectest/exectest.go
+++ b/exectest/exectest.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2020-2022  David Tagatac <david@tagatac.net>
+// See main.go for usage terms.
+
+// Package exectest allows for testing controlled responses from a an os/exec
+// Cmd. It is imported and used in tests for any package that uses os/exec Cmds.
+package exectest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// GenFakeExecCommand works by running the specific test TestRunExecCmd in the
+// package using the fake command as a separate process. That test should be a
+// thin wrapper on RunExecCmd below.
+// Adapted from https://npf.io/2015/06/testing-exec-command/.
+func GenFakeExecCommand(output, err string) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestRunExecCmd", "--", name}
+		cs = append(cs, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{
+			"BAGOUP_WANT_TEST_RUN_EXEC_CMD=1",
+			fmt.Sprintf("BAGOUP_TEST_RUN_EXEC_CMD_OUTPUT=%s", output),
+			fmt.Sprintf("BAGOUP_TEST_RUN_EXEC_CMD_ERROR=%s", err),
+		}
+		return cmd
+	}
+}
+
+// RunExecCmd writes the messages specified as envrionment variables in
+// GenFakeExecCommand, to stdout and stderr before exiting with the correct exit
+// code.
+func RunExecCmd() {
+	if os.Getenv("BAGOUP_WANT_TEST_RUN_EXEC_CMD") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stdout, os.Getenv("BAGOUP_TEST_RUN_EXEC_CMD_OUTPUT"))
+	err := os.Getenv("BAGOUP_TEST_RUN_EXEC_CMD_ERROR")
+	if err != "" {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/opsys/opsys.go
+++ b/opsys/opsys.go
@@ -80,7 +80,7 @@ type (
 )
 
 // NewOS returns an OS from a given filesystem, os Stat, and exec Command.
-func NewOS(fs afero.Fs, osStat func(string) (os.FileInfo, error), execCommand func(string, ...string) *exec.Cmd, sc scall.Syscall) (OS, error) {
+func NewOS(fs afero.Fs, osStat func(string) (os.FileInfo, error), sc scall.Syscall) (OS, error) {
 	var openFilesLimit syscall.Rlimit
 	if err := sc.Getrlimit(syscall.RLIMIT_NOFILE, &openFilesLimit); err != nil {
 		return nil, errors.Wrap(err, "check file count limit")
@@ -89,7 +89,7 @@ func NewOS(fs afero.Fs, osStat func(string) (os.FileInfo, error), execCommand fu
 		Fs:                 fs,
 		Converter:          heic2jpg.NewConverter(),
 		osStat:             osStat,
-		execCommand:        execCommand,
+		execCommand:        exec.Command,
 		Syscall:            sc,
 		openFilesLimitHard: openFilesLimit.Max,
 		openFilesLimitSoft: int(openFilesLimit.Cur),


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**: When the `text` column in the `message` table is empty, use [python-typedstream](https://github.com/dgelessus/python-typedstream) to decode the binary data in the `attributedBody` column.

**Why this change is being made**: Mac OS 13 changes Messages to not always contain data in the `text` column. In those cases, the text appears to be encoded as a binary blob in the `attributedBody` column.

**Related issue(s)**: Fixes #41 

**Follow-up changes needed**:
1. Improve performance and remove the `python-typedstream` dependency by coding its logic in Go.
2. Test that this change is safe for Mac OS prior to Ventura.

**Is the change completely covered by unit tests? If not, why not?**: Yes
