### PR TITLE
Move from Travis-CI to Github Actions

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -12,8 +12,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # - name: Install Homebrew
+    #   run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
     - name: Install wkhtmltopdf
-      run: sudo apt-get -y install wkhtmltopdf
+      run: brew install wkhtmltopdf
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -12,9 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # - name: Install Homebrew
-    #   run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
     - name: Install wkhtmltopdf
       run: brew install wkhtmltopdf
 
@@ -30,4 +27,6 @@ jobs:
       run: make test
 
     - name: Upload Code Coverage
-      run: make codecov
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -1,0 +1,27 @@
+name: Makefile CI
+
+on:
+  push: {}
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install wkhtmltopdf
+      run: sudo apt-get -y install wkhtmltopdf
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.x
+
+    - name: Build
+      run: make
+
+    - name: Test
+      run: make test

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
 
-  build:
-    runs-on: ubuntu-latest
+  build-and-test:
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
 
@@ -25,3 +25,6 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Upload Code Coverage
+      run: make codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go:
-  - 1.x
-before_install:
-  - sudo apt-get -y install wkhtmltopdf
-script:
-  - xvfb-run make test
-after_success:
-  - make codecov

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: bagoup
 bagoup: $(SRC) $(TEMPLATES) download
 	go build $(LDFLAGS) -o $@ cmd/bagoup/main.go
 
-.PHONY: deps download from-archive generate test zip clean codecov
+.PHONY: deps download from-archive generate test zip clean
 
 deps:
 	go get -u -v ./...
@@ -46,13 +46,3 @@ clean:
 	rm -vrf bagoup \
 	$(COVERAGE_FILE) \
 	$(ZIPFILE)
-
-codecov:
-	curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import
-	curl -Os https://uploader.codecov.io/latest/linux/codecov
-	curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-	curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-	gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
-	shasum -a 256 -c codecov.SHA256SUM
-	chmod +x codecov
-	./codecov


### PR DESCRIPTION
**What is changing**: Move from Travis-CI to Github Actions.

**Why this change is being made**: Travis-CI doesn't seem to be working.

**Related issue(s)**: https://travis-ci.community/t/false-statement-builds-have-been-temporarily-disabled-for-private-and-public-repositories-due-to-a-negative-credit-balance/13557

**Follow-up changes needed**: N/A

**Is the change completely covered by unit tests? If not, why not?**: N/A
