### PR TITLE
Modernize all dates in the chat_message_join table

### DIFF
--- a/chatdb/chatdb.go
+++ b/chatdb/chatdb.go
@@ -252,6 +252,11 @@ func (d chatDB) GetMessageIDs(chatID int) ([]DatedMessageID, error) {
 		if err := rows.Scan(&id, &date); err != nil {
 			return nil, errors.Wrapf(err, "read message ID for chat ID %d", chatID)
 		}
+		// We can't trust that all of the dates in the chat_message_join table have
+		// been converted (see https://github.com/tagatac/bagoup/issues/40).
+		if date < 1_000*_modernVersionDateDivisor {
+			date *= _modernVersionDateDivisor
+		}
 		msgIDs = append(msgIDs, DatedMessageID{id, date})
 	}
 	return msgIDs, nil

--- a/chatdb/chatdb_test.go
+++ b/chatdb/chatdb_test.go
@@ -316,12 +316,12 @@ func TestGetMessageIDs(t *testing.T) {
 			setupMock: func(sMock sqlmock.Sqlmock) {
 				rows := sqlmock.NewRows([]string{"message_id", "message_date"}).
 					AddRow(192, 593720716622331392).
-					AddRow(168, 601412272470654464)
+					AddRow(168, 601412272)
 				sMock.ExpectQuery("SELECT message_id, message_date FROM chat_message_join WHERE chat_id=42").WillReturnRows(rows)
 			},
 			wantIDs: []DatedMessageID{
 				{192, 593720716622331392},
-				{168, 601412272470654464},
+				{168, 601412272000000000},
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**: If a date from the `chat_message_join` table is not already modernized, modernize it (multiply by 1B).

**Why this change is being made**: It is possible that some of the dates have been modernized, and others have not.

**Related issue(s)**: Fixes #40 

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: Yes
