### PR TITLE
Use an objective C program to decode typedstreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .vscode/
 bagoup
+typedstream-decode
+!cmd/*
 bagoup-*-*-*.zip
 coverage.out

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,16 @@ SRC=$(shell find . -type f -name '*.go' -not -name '*_test.go' -not -name 'mock_
 TEMPLATES=$(shell find . -type f -name '*.tmpl')
 LDFLAGS=-ldflags '-X "main._version=$(BAGOUP_VERSION) $(OS)/$(HW)"'
 
-build: bagoup
+build: bagoup typedstream-decode
 
 bagoup: $(SRC) $(TEMPLATES) download
 	go build $(LDFLAGS) -o $@ cmd/bagoup/main.go
 
-.PHONY: deps download from-archive generate test zip clean
+.PHONY: deps download from-archive generate test typedstream-decode zip clean
+
+typedstream-decode:
+	make -C cmd/typedstream-decode
+	cp -vf cmd/typedstream-decode/typedstream-decode .
 
 deps:
 	go get -u -v ./...
@@ -44,5 +48,7 @@ zip: build
 
 clean:
 	rm -vrf bagoup \
+	typedstream-decode \
 	$(COVERAGE_FILE) \
 	$(ZIPFILE)
+	make -C cmd/typedstream-decode clean

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC=$(shell find . -type f -name '*.go' -not -name '*_test.go' -not -name 'mock_
 TEMPLATES=$(shell find . -type f -name '*.tmpl')
 LDFLAGS=-ldflags '-X "main._version=$(BAGOUP_VERSION) $(OS)/$(HW)"'
 
-build: bagoup typedstream-decode
+build: typedstream-decode bagoup
 
 bagoup: $(SRC) $(TEMPLATES) download
 	go build $(LDFLAGS) -o $@ cmd/bagoup/main.go

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ $ cat "messages-export/Novak Djokovic/iMessage;-;+3815555555555.txt"
 ### PDF (--pdf flag)
 ![Example PDF Export](example-exports/example-pdf-screenshot.png)
 ## Dependencies
-- [python-typedstream](https://github.com/dgelessus/python-typedstream) (for compatibility with Messages on Mac OS 13 and newer)
-```
-git clone git@github.com:dgelessus/python-typedstream.git
-cd python-typedstream
-python3 -m pip install .
-```
 - [wkhtmltopdf](https://wkhtmltopdf.org/) (for exporting to PDF; not needed for exports to plaintext)
 ```
 brew install wkhtmltopdf

--- a/chatdb/chatdb_test.go
+++ b/chatdb/chatdb_test.go
@@ -478,19 +478,23 @@ func TestGetMessage(t *testing.T) {
 			wantValid:   true,
 		},
 		{
-			msg: "message encoded in attributedBody",
+			msg: "2FA code encoded in attributedBody",
 			setupQuery: func(query *sqlmock.ExpectedQuery) {
 				rows := sqlmock.NewRows([]string{"is_from_me", "handle_id", "text", "attributedBody", "date"}).
 					AddRow(0, 10, nil, "", "2019-10-04 18:26:31")
 				query.WillReturnRows(rows)
 			},
-			ptsOutput: `type b'@': object of class NSMutableAttributedString v0, extends NSAttributedString v0, extends NSObject v0:
-	super object: <NSObject>
-	type b'@': NSMutableString('message text')
-	group:
-		type b'i': 1
-		type b'I': 28`,
-			wantMessage: "[2019-10-04 18:26:31] testhandle1: message text\n",
+			ptsOutput: `Venmo here! NEVER share this code via call/text. ONLY YOU should enter the code. BEWARE: If someone asks for the code, it's a scam. Code: {
+    "__kIMMessagePartAttributeName" = 0;
+}555555{
+    "__kIMDataDetectedAttributeName" = {length = 553, bytes = 0x62706c69 73743030 d4010203 04050607 ... 00000000 00000193 };
+    "__kIMMessagePartAttributeName" = 0;
+    "__kIMOneTimeCodeAttributeName" =     {
+        code = 555555;
+        displayCode = 555555;
+    };
+}`,
+			wantMessage: "[2019-10-04 18:26:31] testhandle1: Venmo here! NEVER share this code via call/text. ONLY YOU should enter the code. BEWARE: If someone asks for the code, it's a scam. Code: 555555\n",
 			wantValid:   true,
 		},
 		{
@@ -526,17 +530,16 @@ func TestGetMessage(t *testing.T) {
 					AddRow(0, 10, nil, "", "2019-10-04 18:26:31")
 				query.WillReturnRows(rows)
 			},
-			ptsErr:      "this is a pytypedstream error",
+			ptsErr:      "this is a typedstream-decode error",
 			wantMessage: "[2019-10-04 18:26:31] testhandle1: \n",
 		},
 		{
-			msg: "decoded attributedBody doesn't match regexp",
+			msg: "no valid text or attributedBody",
 			setupQuery: func(query *sqlmock.ExpectedQuery) {
 				rows := sqlmock.NewRows([]string{"is_from_me", "handle_id", "text", "attributedBody", "date"}).
-					AddRow(0, 10, nil, "", "2019-10-04 18:26:31")
+					AddRow(0, 10, nil, nil, "2019-10-04 18:26:31")
 				query.WillReturnRows(rows)
 			},
-			ptsOutput:   "this is a bad decoding",
 			wantMessage: "[2019-10-04 18:26:31] testhandle1: \n",
 		},
 	}

--- a/cmd/typedstream-decode/.gitignore
+++ b/cmd/typedstream-decode/.gitignore
@@ -1,0 +1,3 @@
+typedstream-decode
+main.o
+decode.o

--- a/cmd/typedstream-decode/Makefile
+++ b/cmd/typedstream-decode/Makefile
@@ -1,17 +1,13 @@
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-mkfile_dir := $(dir $(mkfile_path))
-
 build: typedstream-decode
 
 typedstream-decode: main.o decode.o
-	clang -o $@ decode.o $< -framework Foundation
+	swiftc -v -o $@ $^
 
-main.o: main.swift decode.h typedstream-parser-Bridging-Header.h
-	swiftc -c -import-objc-header typedstream-parser-Bridging-Header.h $<
+main.o: main.swift decode.h
+	swiftc -v -c -import-objc-header decode.h $< -framework Foundation
 
-decode.o: decode.m decode.h typedstream-parser-Bridging-Header.h
-	clang -c $< -fobjc-arc -fmodules -I $(mkfile_dir)
+decode.o: decode.m
+	clang -v -c $< -fobjc-arc -fmodules
 
 clean:
 	rm -vf typedstream-decode main.o decode.o
-

--- a/cmd/typedstream-decode/Makefile
+++ b/cmd/typedstream-decode/Makefile
@@ -1,0 +1,17 @@
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+mkfile_dir := $(dir $(mkfile_path))
+
+build: typedstream-decode
+
+typedstream-decode: main.o decode.o
+	clang -o $@ decode.o $< -framework Foundation
+
+main.o: main.swift decode.h typedstream-parser-Bridging-Header.h
+	swiftc -c -import-objc-header typedstream-parser-Bridging-Header.h $<
+
+decode.o: decode.m decode.h typedstream-parser-Bridging-Header.h
+	clang -c $< -fobjc-arc -fmodules -I $(mkfile_dir)
+
+clean:
+	rm -vf typedstream-decode main.o decode.o
+

--- a/cmd/typedstream-decode/decode.h
+++ b/cmd/typedstream-decode/decode.h
@@ -1,0 +1,20 @@
+//
+//  decode.h
+//  typedstream-parser
+//
+//  Created by David Tagatac on 11/12/23.
+//
+
+#ifndef decode_h
+#define decode_h
+
+#import <Foundation/Foundation.h>
+
+@interface Decode : NSObject
+
+- (void) decode:(NSString *) filename;
+- (void) decodeStdin;
+
+@end
+
+#endif /* decode_h */

--- a/cmd/typedstream-decode/decode.h
+++ b/cmd/typedstream-decode/decode.h
@@ -1,6 +1,6 @@
 //
 //  decode.h
-//  typedstream-parser
+//  typedstream-decode
 //
 //  Created by David Tagatac on 11/12/23.
 //

--- a/cmd/typedstream-decode/decode.m
+++ b/cmd/typedstream-decode/decode.m
@@ -1,0 +1,27 @@
+//
+//  decode.m
+//  typedstream-parser
+//
+//  Created by David Tagatac on 11/12/23.
+//
+
+#import <Foundation/Foundation.h>
+#import "decode.h"
+
+@implementation Decode
+
+- (void) decode:(NSString *) filename {
+    NSUnarchiver *typedStreamUnarchiver = [[NSUnarchiver alloc] initForReadingWithData:[NSData dataWithContentsOfFile:filename]];
+    id object = [typedStreamUnarchiver decodeObject];
+    printf("%s\n", [[NSString stringWithFormat:@"%@", object] UTF8String]);
+}
+
+- (void) decodeStdin {
+    NSFileHandle *input = [NSFileHandle fileHandleWithStandardInput];
+    NSData *inputData = [NSData dataWithData:[input readDataToEndOfFile]];
+    NSUnarchiver *typedStreamUnarchiver = [[NSUnarchiver alloc] initForReadingWithData:inputData];
+    id object = [typedStreamUnarchiver decodeObject];
+    printf("%s\n", [[NSString stringWithFormat:@"%@", object] UTF8String]);
+}
+
+@end

--- a/cmd/typedstream-decode/decode.m
+++ b/cmd/typedstream-decode/decode.m
@@ -1,11 +1,10 @@
 //
 //  decode.m
-//  typedstream-parser
+//  typedstream-decode
 //
 //  Created by David Tagatac on 11/12/23.
 //
 
-#import <Foundation/Foundation.h>
 #import "decode.h"
 
 @implementation Decode

--- a/cmd/typedstream-decode/main.swift
+++ b/cmd/typedstream-decode/main.swift
@@ -1,6 +1,6 @@
 //
 //  main.swift
-//  typedstream-parser
+//  typedstream-decode
 //
 //  Created by David Tagatac on 11/12/23.
 //

--- a/cmd/typedstream-decode/main.swift
+++ b/cmd/typedstream-decode/main.swift
@@ -1,0 +1,10 @@
+//
+//  main.swift
+//  typedstream-parser
+//
+//  Created by David Tagatac on 11/12/23.
+//
+
+import Foundation
+
+Decode().decodeStdin()

--- a/cmd/typedstream-decode/typedstream-parser-Bridging-Header.h
+++ b/cmd/typedstream-decode/typedstream-parser-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "decode.h"

--- a/cmd/typedstream-decode/typedstream-parser-Bridging-Header.h
+++ b/cmd/typedstream-decode/typedstream-parser-Bridging-Header.h
@@ -1,5 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import "decode.h"


### PR DESCRIPTION
**What is changing**: Use an objective C program wrapped in Swift to decode `attributedBody`s instead of `python-typedstream`.

**Why this change is being made**:
1. More than 10x faster performance

Exporting 13k messages before this change:
```
BAGOUP RESULTS:
bagoup version: 2.3-8-gcb949d8 Darwin/arm64
Export folder: "messages-export"
Export files written: 88
Chats exported: 93
Valid messages exported: 13445
Invalid messages exported (see warnings above): 10
Attachments copied: 0
Attachments referenced or embedded: 855
	text/vcard: 3
	audio/x-m4a: 1
	application/octet-stream: 429
	image/jpeg: 111
	image/tiff: 3
	image/png: 55
	video/quicktime: 20
	image/heic: 208
	image/gif: 20
	application/pdf: 3
	image/heic-sequence: 1
	text/x-vlocation: 1
Attachments embedded: 0
Attachments missing (see warnings above): 7
HEIC conversions completed: 0
HEIC conversions failed (see warnings above): 0
Time elapsed: 3m44.237393208s
```
Exporting 13k messages after this change:
```
BAGOUP RESULTS:
bagoup version: 2.3-10-ga97c0f6 Darwin/arm64
Export folder: "messages-export"
Export files written: 88
Chats exported: 93
Valid messages exported: 13445
Invalid messages exported (see warnings above): 10
Attachments copied: 0
Attachments referenced or embedded: 855
	application/octet-stream: 429
	image/tiff: 3
	text/vcard: 3
	image/heic-sequence: 1
	audio/x-m4a: 1
	image/jpeg: 111
	image/heic: 208
	image/png: 55
	video/quicktime: 20
	image/gif: 20
	application/pdf: 3
	text/x-vlocation: 1
Attachments embedded: 0
Attachments missing (see warnings above): 7
HEIC conversions completed: 0
HEIC conversions failed (see warnings above): 0
Time elapsed: 18.700830667s
```

2. Removes a dependency

**Related issue(s)**: Closes #43 

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: Yes
