### PR TITLE
Break large chats into multiple PDF files

### DIFF
--- a/internal/bagoup/export_test.go
+++ b/internal/bagoup/export_test.go
@@ -193,9 +193,9 @@ func TestExportChats(t *testing.T) {
 					}, nil),
 					dbMock.EXPECT().GetMessageIDs(1),
 					osMock.EXPECT().MkdirAll("messages-export/testdisplayname", os.ModePerm),
+					osMock.EXPECT().MkdirAll("messages-export/testdisplayname/attachments", os.ModePerm),
 					osMock.EXPECT().Create("messages-export/testdisplayname/testguid.txt").Return(chatFile, nil),
 					osMock.EXPECT().NewTxtOutFile(chatFile).Return(ofMocks[0]),
-					osMock.EXPECT().MkdirAll("messages-export/testdisplayname/attachments", os.ModePerm),
 					ofMocks[0].EXPECT().Flush(),
 					osMock.EXPECT().GetOpenFilesLimit().Return(256),
 				)


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**: 
When a given chat (or set of entity chats) has over 3072 messages, PDF exports for that chat are now broken into multiple files.

**Why this change is being made**: 
PDFs over 400MB were starting to fail to write properly (filled with unknown characters).

**Related issue(s)**: None

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: Yes
