### PR TITLE
Remove unnecessary dependencies from Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC=$(shell find . -type f -name '*.go' -not -name '*_test.go' -not -name 'mock_
 TEMPLATES=$(shell find . -type f -name '*.tmpl')
 LDFLAGS=-ldflags '-X "main._version=$(BAGOUP_VERSION) $(OS)/$(HW)"'
 
-PKGS=$(shell go list ./... | grep -v '/mock_' | tr '\n' ' ')
+PKGS=$(shell go list ./... | grep --invert-match '/mock_' | tr '\n' ' ')
 EXCLUDE_PKGS=\
 	github.com/tagatac/bagoup/v2/example-exports \
 	github.com/tagatac/bagoup/v2/exectest
@@ -30,7 +30,6 @@ bin/bagoup: $(SRC) $(TEMPLATES) download
 deps:
 	go get -u -v ./...
 	go mod tidy -v
-	go get -u golang.org/x/tools/cover
 
 download:
 	go mod download
@@ -42,7 +41,7 @@ example: example-exports/examplegen.go download
 from-archive:
 	BAGOUP_VERSION=$(shell pwd | sed 's/.*bagoup-//g') make build
 
-generate: clean deps
+generate:
 	go install github.com/golang/mock/mockgen@latest
 	go generate ./...
 

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,4 @@ require (
 	github.com/google/go-cmp v0.5.4 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.16.0 h1:GO788SKMRunPIBCXiQyo2AaexLstOrVhuAL5YwsckQM=
-golang.org/x/tools v0.16.0/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**:
- Stop including `tools/cover` as a dependency of bagoup.
- Stop running `clean` and `deps` targets before `generate`.
- Use long versions of commandline flags where possible.

**Why this change is being made**:
- Get rid of some noise when running these targets.
- Make the commandline flags more readable.

**Related issue(s)**: N/A

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: N/A
