### PR TITLE
Use the retry-action action to retry the codecov uploader action

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -10,6 +10,7 @@ jobs:
   build-and-test:
     runs-on: macos-latest
     steps:
+
     - uses: actions/checkout@v3
 
     - name: Install wkhtmltopdf
@@ -27,6 +28,10 @@ jobs:
       run: make test
 
     - name: Upload Code Coverage
-      uses: codecov/codecov-action@v3
+      uses: Wandalen/wretry.action@v1
       with:
-        fail_ci_if_error: true
+        action: codecov/codecov-action@v3
+        attempt_limit: 10
+        attempt_delay: 10000
+        with: |
+          fail_ci_if_error: true


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**: Use https://github.com/Wandalen/wretry.action to retry https://github.com/codecov/codecov-action.
Inspired by https://github.com/xdslproject/xdsl/pull/1288.

**Why this change is being made**: The codecov action fails often:
- https://github.com/tagatac/bagoup/actions/runs/7089000221/job/19292737639#step:7:31
- https://github.com/tagatac/bagoup/actions/runs/7089000221/job/19293026056#step:7:31
- https://github.com/tagatac/bagoup/actions/runs/7089000221/job/19293200011#step:7:31
- https://github.com/tagatac/bagoup/actions/runs/7089000221/job/19293438478#step:7:31
```
[2023-12-04T15:47:46.155Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```

But succeeds eventually on retry: https://github.com/tagatac/bagoup/actions/runs/7089000221/job/19293933175#step:7:34

**Related issue(s)**: https://github.com/codecov/codecov-action/issues/926

**Follow-up changes needed**: Remove this when https://github.com/codecov/codecov-action/issues/926 is resolved (or Github Actions offers a built-in retry mechanism for actions).

**Is the change completely covered by unit tests? If not, why not?**: N/A
