### PR TITLE
Fix Google 2FA code attribute bodies

### DIFF
--- a/chatdb/message.go
+++ b/chatdb/message.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	_TypedStreamAttributeRE          = regexp.MustCompile(`(\{\n)? {4}"__kIM[[:alpha:]]+" = ([^\n]+);\n\}?`)
-	_TypedStreamMultilineAttributeRE = regexp.MustCompile(`(\{\n)? {4}"__kIM[[:alpha:]]+" = {5}\{\n( {8}[[:alpha:]]+ = \d+;\n)+ {4}\};\n\}?`)
+	_TypedStreamMultilineAttributeRE = regexp.MustCompile(`(\{\n)? {4}"__kIM[[:alpha:]]+" = {5}\{\n( {8}[[:alpha:]]+ = [\w-"]+;\n)+ {4}\};\n\}?`)
 )
 
 // DatedMessageID pairs a message ID and its date, in the legacy date format.

--- a/chatdb/message_test.go
+++ b/chatdb/message_test.go
@@ -208,6 +208,27 @@ func TestGetMessage(t *testing.T) {
 			wantValid:   true,
 		},
 		{
+			msg: "Google 2FA code encoded in attributedBody",
+			setupQuery: func(query *sqlmock.ExpectedQuery) {
+				rows := sqlmock.NewRows([]string{"is_from_me", "handle_id", "text", "attributedBody", "date"}).
+					AddRow(0, 10, nil, "", "2023-12-17 21:27:07")
+				query.WillReturnRows(rows)
+			},
+			ptsOutput: `G-123456{
+    "__kIMDataDetectedAttributeName" = {length = 537, bytes = 0x62706c69 73743030 d4010203 04050607 ... 00000000 00000185 };
+    "__kIMMessagePartAttributeName" = 0;
+    "__kIMOneTimeCodeAttributeName" =     {
+        code = 123456;
+        displayCode = "G-123456";
+    };
+} is your Google verification code.{
+    "__kIMMessagePartAttributeName" = 0;
+}
+`,
+			wantMessage: "[2023-12-17 21:27:07] testhandle1: G-123456 is your Google verification code.\n",
+			wantValid:   true,
+		},
+		{
 			msg: "DB error",
 			setupQuery: func(query *sqlmock.ExpectedQuery) {
 				query.WillReturnError(errors.New("this is a DB error"))


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**: Make the attributedbody regex more general to catch multiline attributes with values like "G-123456".

**Why this change is being made**: Google's 2FA codes include letters, hyphens, and double quotes.

**Related issue(s)**: Fixes #60 

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: Yes
