### PR TITLE
Add option validation

### DIFF
--- a/cmd/bagoup/main.go
+++ b/cmd/bagoup/main.go
@@ -47,6 +47,7 @@ func main() {
 		os.Exit(0)
 	}
 	logFatalOnErr(errors.Wrap(err, "parse flags"))
+	logFatalOnErr(errors.Wrap(bagoup.ValidateOptions(opts), "validate options"))
 	if opts.PrintVersion {
 		fmt.Printf("bagoup version %s\n%s\n", _version, _license)
 		return

--- a/internal/bagoup/bagoup.go
+++ b/internal/bagoup/bagoup.go
@@ -30,23 +30,6 @@ const (
 const _readmeURL = "https://github.com/tagatac/bagoup/blob/master/README.md#protected-file-access"
 
 type (
-	// Options are the commandline options that can be passed to the bagoup
-	// command.
-	Options struct {
-		DBPath          string   `short:"i" long:"db-path" description:"Path to the Messages chat database file" default:"~/Library/Messages/chat.db"`
-		ExportPath      string   `short:"o" long:"export-path" description:"Path to which the Messages will be exported" default:"messages-export"`
-		MacOSVersion    *string  `short:"m" long:"mac-os-version" description:"Version of Mac OS, e.g. '10.15', from which the Messages chat database file was copied (not needed if bagoup is running on the same Mac)"`
-		ContactsPath    *string  `short:"c" long:"contacts-path" description:"Path to the contacts vCard file"`
-		SelfHandle      string   `short:"s" long:"self-handle" description:"Prefix to use for for messages sent by you" default:"Me"`
-		SeparateChats   bool     `long:"separate-chats" description:"Do not merge chats with the same contact (e.g. iMessage and SMS) into a single file"`
-		OutputPDF       bool     `short:"p" long:"pdf" description:"Export text and images to PDF files (requires full disk access)"`
-		IncludePPA      bool     `long:"include-ppa" description:"Include plugin payload attachments (e.g. link previews) in generated PDFs"`
-		CopyAttachments bool     `short:"a" long:"copy-attachments" description:"Copy attachments to the same folder as the chat which included them (requires full disk access)"`
-		PreservePaths   bool     `short:"r" long:"preserve-paths" description:"When copying attachments, preserve the full path instead of co-locating them with the chats which included them"`
-		AttachmentsPath string   `short:"t" long:"attachments-path" description:"Root path to the attachments (useful for re-running bagoup on an export created with the --copy-attachments and --preserve-paths flags)" default:"/"`
-		Entities        []string `short:"e" long:"entity" description:"An entity name to include in the export (matches the folder name in the export, e.g. \"John Smith\" or \"+15551234567\"). If given, other entities' chats will not be exported. If this flag is used multiple times, all entities specified will be exported."`
-		PrintVersion    bool     `short:"v" long:"version" description:"Show the version of bagoup"`
-	}
 	configuration struct {
 		Options
 		opsys.OS

--- a/internal/bagoup/options.go
+++ b/internal/bagoup/options.go
@@ -1,0 +1,35 @@
+package bagoup
+
+import "github.com/pkg/errors"
+
+type // Options are the commandline options that can be passed to the bagoup
+// command.
+Options struct {
+	DBPath          string   `short:"i" long:"db-path" description:"Path to the Messages chat database file" default:"~/Library/Messages/chat.db"`
+	ExportPath      string   `short:"o" long:"export-path" description:"Path to which the Messages will be exported" default:"messages-export"`
+	MacOSVersion    *string  `short:"m" long:"mac-os-version" description:"Version of Mac OS, e.g. '10.15', from which the Messages chat database file was copied (not needed if bagoup is running on the same Mac)"`
+	ContactsPath    *string  `short:"c" long:"contacts-path" description:"Path to the contacts vCard file"`
+	SelfHandle      string   `short:"s" long:"self-handle" description:"Prefix to use for for messages sent by you" default:"Me"`
+	SeparateChats   bool     `long:"separate-chats" description:"Do not merge chats with the same contact (e.g. iMessage and SMS) into a single file"`
+	OutputPDF       bool     `short:"p" long:"pdf" description:"Export text and images to PDF files (requires full disk access)"`
+	IncludePPA      bool     `long:"include-ppa" description:"Include plugin payload attachments (e.g. link previews) in generated PDFs"`
+	CopyAttachments bool     `short:"a" long:"copy-attachments" description:"Copy attachments to the same folder as the chat which included them (requires full disk access)"`
+	PreservePaths   bool     `short:"r" long:"preserve-paths" description:"When copying attachments, preserve the full path instead of co-locating them with the chats which included them"`
+	AttachmentsPath string   `short:"t" long:"attachments-path" description:"Root path to the attachments (useful for re-running bagoup on an export created with the --copy-attachments and --preserve-paths flags)" default:"/"`
+	Entities        []string `short:"e" long:"entity" description:"An entity name to include in the export (matches the folder name in the export, e.g. \"John Smith\" or \"+15551234567\"). If given, other entities' chats will not be exported. If this flag is used multiple times, all entities specified will be exported."`
+	PrintVersion    bool     `short:"v" long:"version" description:"Show the version of bagoup"`
+}
+
+func ValidateOptions(opts Options) error {
+	if opts.IncludePPA && !opts.OutputPDF {
+		return errors.New("the --include-ppa flag requires the --pdf flag")
+	}
+	if opts.PreservePaths && !opts.CopyAttachments {
+		return errors.New("the --preserve-paths flag requires the --copy-attachments flag")
+	}
+	usingAttachments := opts.CopyAttachments || opts.OutputPDF
+	if opts.AttachmentsPath != "/" && !usingAttachments {
+		return errors.New("the --attachments-path flag requires a flag that uses those attachments: --copy-attachments or --pdf")
+	}
+	return nil
+}

--- a/internal/bagoup/options_test.go
+++ b/internal/bagoup/options_test.go
@@ -1,0 +1,62 @@
+package bagoup_test
+
+import (
+	"testing"
+
+	"github.com/tagatac/bagoup/v2/internal/bagoup"
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateOptions(t *testing.T) {
+	tests := []struct {
+		msg     string
+		opts    bagoup.Options
+		wantErr string
+	}{
+		{
+			msg: "no errors",
+			opts: bagoup.Options{
+				AttachmentsPath: "/",
+			},
+			wantErr: "",
+		},
+		{
+			msg: "include plugin payload attachments without PDF output",
+			opts: bagoup.Options{
+				OutputPDF:       false,
+				IncludePPA:      true,
+				AttachmentsPath: "/",
+			},
+			wantErr: "the --include-ppa flag requires the --pdf flag",
+		},
+		{
+			msg: "preserve paths without copying attachments",
+			opts: bagoup.Options{
+				CopyAttachments: false,
+				PreservePaths:   true,
+				AttachmentsPath: "/",
+			},
+			wantErr: "the --preserve-paths flag requires the --copy-attachments flag",
+		},
+		{
+			msg: "custom attachments path without using attachments",
+			opts: bagoup.Options{
+				CopyAttachments: false,
+				OutputPDF:       false,
+				AttachmentsPath: "testpath",
+			},
+			wantErr: "the --attachments-path flag requires a flag that uses those attachments: --copy-attachments or --pdf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			err := bagoup.ValidateOptions(tt.opts)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
**What is changing**: Add checks that nonsensical combinations of flags are not used.

**Why this change is being made**:
1. To avoid letting users perform long exports only to learn that one of the flags they used was unexpectedly ignored.
2. To avoid performing functions in unexpected situations, e.g. creating a tilde expansion file when there are no copied attachments.

**Related issue(s)**: Closes #68 

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: Yes
