### PR TITLE
Use installer to install wkhtmltopdf

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -14,7 +14,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install wkhtmltopdf
-      run: brew install wkhtmltopdf
+      run: |
+        wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg
+        sudo installer -pkg wkhtmltox-0.12.6-2.macos-cocoa.pkg -target /
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ $ cat "messages-export/Novak Djokovic/iMessage;-;+3815555555555.txt"
 ## Dependencies
 - [wkhtmltopdf](https://wkhtmltopdf.org/) (for exporting to PDF; not needed for exports to plaintext)
 ```
-brew install wkhtmltopdf
+wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg
+sudo installer -pkg wkhtmltox-0.12.6-2.macos-cocoa.pkg -target /
 ```
 
 ## Installation


### PR DESCRIPTION
<!-- Please add a title in the form of a great git commit message in the imperative mood (https://cbea.ms/git-commit/) -->

**What is changing**: Use `wget` to download, and `installer` to install, `wkhtmltopdf` instead of homebrew.

**Why this change is being made**: homebrew has discontinued `wkhtmltopdf`.

**Follow-up changes needed**: #72 

**Is the change completely covered by unit tests? If not, why not?**: No code changes.
