### PR TITLE
Add a test to compare the versioned example export with a newly generated PDF

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -13,10 +13,16 @@ jobs:
 
     - uses: actions/checkout@v4
 
+    - name: Install WeasyPrint
+      run: brew install weasyprint
+
     - name: Install wkhtmltopdf
       run: |
         wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg
         sudo installer -pkg wkhtmltox-0.12.6-2.macos-cocoa.pkg -target /
+
+    - name: Install pdf-diff
+      run: brew install pdf-diff
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -38,3 +44,6 @@ jobs:
         with: |
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Test PDF Creation
+      run: make test-pdf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 bin
 bagoup-*-*-*.zip
 coverage.out
+test-pdf

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ test-pdf: download
 	cd example-exports && go run examplegen.go ../test-pdf
 	cd test-pdf && pdf-diff "../example-exports/messages-export-pdf/Novak Djokovic/iMessage,-,+3815555555555.pdf" "messages-export-pdf/Novak Djokovic/iMessage,-,+3815555555555.pdf" > output.txt
 	cat test-pdf/output.txt
-	$(eval pdf-diff-result := $(shell tail -n 1 test-pdf/output.txt))
-	@echo "Output: $(pdf-diff-result)"
-	@if [ "$(pdf-diff-result)" != "The pages number 1 are the same." ]; then \
+	@pdf_diff_result=$$(tail -n 1 test-pdf/output.txt); \
+	echo "Output: $$pdf_diff_result"; \
+	if [ "$$pdf_diff_result" != "The pages number 1 are the same." ]; then \
 		echo "The generated PDF differs from the example"; \
 		exit 1; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ test-pdf: download
 	cd example-exports && go run examplegen.go ../test-pdf
 	cd test-pdf && pdf-diff "../example-exports/messages-export-pdf/Novak Djokovic/iMessage,-,+3815555555555.pdf" "messages-export-pdf/Novak Djokovic/iMessage,-,+3815555555555.pdf" > output.txt
 	cat test-pdf/output.txt
-	$(eval pdf-diff-result := $(shell cat test-pdf/output.txt | tail -n 1))
+	$(eval pdf-diff-result := $(shell tail -n 1 test-pdf/output.txt))
+	@echo "Output: $(pdf-diff-result)"
 	@if [ "$(pdf-diff-result)" != "The pages number 1 are the same." ]; then \
 		echo "The generated PDF differs from the example"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ test-pdf: download
 	cd test-pdf && pdf-diff "../example-exports/messages-export-pdf/Novak Djokovic/iMessage,-,+3815555555555.pdf" "messages-export-pdf/Novak Djokovic/iMessage,-,+3815555555555.pdf" > output.txt
 	cat test-pdf/output.txt
 	@pdf_diff_result=$$(tail -n 1 test-pdf/output.txt); \
-	echo "Output: $$pdf_diff_result"; \
 	if [ "$$pdf_diff_result" != "The pages number 1 are the same." ]; then \
 		echo "The generated PDF differs from the example"; \
 		exit 1; \

--- a/example-exports/examplegen.go
+++ b/example-exports/examplegen.go
@@ -32,11 +32,20 @@ func main() {
 		log.Panic(errors.Wrap(err, "get working directory"))
 	}
 	parentDir := filepath.Dir(wd)
-	attachmentPath := filepath.Join(parentDir, "opsys/testdata/tennisballs.jpeg")
+	attachmentPath := filepath.Join(
+		parentDir,
+		"opsys",
+		"testdata",
+		"tennisballs.jpeg",
+	)
 
+	exportRoot := ""
+	if len(os.Args) > 1 {
+		exportRoot = os.Args[1]
+	}
 	runs := []parameters{
-		{isPDF: false, exportPath: "messages-export"},
-		{isPDF: true, exportPath: "messages-export-pdf"},
+		{isPDF: false, exportPath: filepath.Join(exportRoot, "messages-export")},
+		{isPDF: true, exportPath: filepath.Join(exportRoot, "messages-export-pdf")},
 	}
 	s := opsys.NewOS(afero.NewOsFs(), os.Stat)
 	for _, params := range runs {


### PR DESCRIPTION
**What is changing**: Add a makefile target that
1. generates example exports and
2. uses `pdf-diff` to compare the generated PDF to the versioned example.

**Why this change is being made**: This is the first integration test for PDF exporting.

**Related issue(s)**: N/A

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: N/A
