### PR TITLE
Add permissions to the workflow file

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -1,5 +1,8 @@
 name: Makefile CI
 
+permissions:
+  contents: read
+
 on:
   push: {}
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/tagatac/bagoup/security/code-scanning/1](https://github.com/tagatac/bagoup/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block to either the workflow root or to the specific job so that the `GITHUB_TOKEN` is restricted to the minimal scopes required. For this workflow, the steps only need to check out code and call external services (Homebrew, wget, installer, Go, make, Codecov). None of these require write access to the repository via `GITHUB_TOKEN`. The minimal safe setting is `contents: read`, which aligns with CodeQL’s suggestion and GitHub’s recommended baseline.

The single best fix, without changing existing functionality, is to set a workflow-wide permissions block with `contents: read`. This will apply to the `build-and-test` job and any future jobs that don’t override permissions, keeps the change small, and is consistent with the analyzer’s “minimal starting point: {contents: read}” message. To implement this, edit `.github/workflows/makefile.yaml` near the top of the file, adding:

```yaml
permissions:
  contents: read
```

right after the `name: Makefile CI` line (or equivalently after the `on:` block). No imports, methods, or additional definitions are required because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
