### PR TITLE
Use ImageMagick to validate test PDF exports

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -60,24 +60,17 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{ matrix.os }}
 
-    - name: Install WeasyPrint and diff-pdf (macOS)
+    - name: Install WeasyPrint, poppler, and imagemagick (macOS)
       if: runner.os == 'macOS'
       run: |
         brew update
-        brew install weasyprint diff-pdf
+        brew install weasyprint poppler imagemagick ghostscript
 
-    - name: Install WeasyPrint, emojis, and diff-pdf (Linux)
+    - name: Install WeasyPrint, emojis, poppler, and imagemagick (Linux)
       if: runner.os == 'Linux'
       run: |
         pipx install weasyprint
-        sudo apt-get install -y fonts-noto-color-emoji make automake g++ libpoppler-glib-dev poppler-utils libwxgtk3.2-dev
-        wget https://github.com/vslavik/diff-pdf/releases/download/v0.5.3/diff-pdf-0.5.3.tar.gz
-        tar xzf diff-pdf-0.5.3.tar.gz
-        cd diff-pdf-0.5.3
-        ./bootstrap
-        ./configure
-        make
-        sudo make install
+        sudo apt-get install -y fonts-noto-color-emoji poppler-utils imagemagick ghostscript
 
     - name: Test Exports
       id: test-exports

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -70,7 +70,10 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         pipx install weasyprint
-        sudo apt-get install -y fonts-noto-color-emoji poppler-utils imagemagick ghostscript
+        sudo apt-get install -y fonts-noto-color-emoji poppler-utils ghostscript
+        wget https://imagemagick.org/archive/binaries/magick
+        chmod +x magick
+        sudo mv magick /usr/local/bin/magick
 
     - name: Test Exports
       id: test-exports

--- a/Makefile
+++ b/Makefile
@@ -59,15 +59,31 @@ test: download
 	go test -race -coverprofile=$(COVERAGE_FILE) -coverpkg=$(PKGS_TO_COVER) $(PKGS_TO_TEST)
 	go tool cover -func=$(COVERAGE_FILE)
 
+define compare-pdf
+	bash -c " \
+		pdfinfo $(EXAMPLE_EXPORTS_DIR)/$(1) | $(PDFINFO_IGNORE_CMD) > $(TEST_EXPORTS_DIR)/$(1).expected.info && \
+		pdfinfo $(TEST_EXPORTS_DIR)/$(1) | $(PDFINFO_IGNORE_CMD) > $(TEST_EXPORTS_DIR)/$(1).actual.info && \
+		diff $(TEST_EXPORTS_DIR)/$(1).expected.info $(TEST_EXPORTS_DIR)/$(1).actual.info"
+	magick compare -verbose -metric SSIM \
+	  \( -density 300 $(EXAMPLE_EXPORTS_DIR)/$(1) -background white -alpha remove \) \
+	  \( -density 300 $(TEST_EXPORTS_DIR)/$(1) -background white -alpha remove \) \
+	  null: 2>&1 \
+		| tee /dev/stderr \
+		| grep -i "all" \
+		| awk 'BEGIN { found=0 } { found=1; val=$$2 } END { \
+			if (!found) exit 1; \
+	    if (val > 0.5) { exit (val >= 0.999 ? 0 : 1) } \
+	    else { exit (val <= 0.001 ? 0 : 1) } \
+		}'
+endef
+
 test-exports: download
 	rm -vrf $(TEST_EXPORTS_DIR)
 	mkdir -vp $(TEST_EXPORTS_DIR)
 	cd example-exports && go run examplegen.go ../$(TEST_EXPORTS_DIR)
 	diff $(EXAMPLE_EXPORTS_DIR)/$(TXT_FILE) $(TEST_EXPORTS_DIR)/$(TXT_FILE)
-	bash -c "diff <(pdfinfo $(EXAMPLE_EXPORTS_DIR)/$(PDF_FILE) | $(PDFINFO_IGNORE_CMD)) <(pdfinfo $(TEST_EXPORTS_DIR)/$(PDF_FILE) | $(PDFINFO_IGNORE_CMD))"
-	diff-pdf -v $(EXAMPLE_EXPORTS_DIR)/$(PDF_FILE) $(TEST_EXPORTS_DIR)/$(PDF_FILE)
-	bash -c "diff <(pdfinfo $(EXAMPLE_EXPORTS_DIR)/$(PDF_FILE_WKHTML) | $(PDFINFO_IGNORE_CMD)) <(pdfinfo $(TEST_EXPORTS_DIR)/$(PDF_FILE_WKHTML) | $(PDFINFO_IGNORE_CMD))"
-	diff-pdf -v $(EXAMPLE_EXPORTS_DIR)/$(PDF_FILE_WKHTML) $(TEST_EXPORTS_DIR)/$(PDF_FILE_WKHTML)
+	$(call compare-pdf,$(PDF_FILE))
+	$(call compare-pdf,$(PDF_FILE_WKHTML))
 
 clean:
 	rm -vrf \

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,6 @@ EXCLUDE_PKGS=\
 PKGS_TO_TEST=$(filter-out $(EXCLUDE_PKGS),$(PKGS))
 PKGS_TO_COVER=$(shell echo "$(PKGS_TO_TEST)" | tr ' ' ',')
 
-EXAMPLE_EXPORT_FILE='Novak Djokovic/iMessage;-;+3815555555555'
-TXT_FILE=messages-export/$(EXAMPLE_EXPORT_FILE).txt
-PDF_FILE=messages-export-pdf/$(EXAMPLE_EXPORT_FILE).pdf
-PDF_FILE_WKHTML=messages-export-wkhtmltopdf/$(EXAMPLE_EXPORT_FILE).pdf
-PDFINFO_IGNORE_CMD=grep -Ev 'Creator|CreationDate|File size|Producer'
 EXAMPLE_EXPORTS_DIR=example-exports/$(OS)
 TEST_EXPORTS_DIR=test-exports
 
@@ -59,31 +54,8 @@ test: download
 	go test -race -coverprofile=$(COVERAGE_FILE) -coverpkg=$(PKGS_TO_COVER) $(PKGS_TO_TEST)
 	go tool cover -func=$(COVERAGE_FILE)
 
-define compare-pdf
-	bash -c " \
-		pdfinfo $(EXAMPLE_EXPORTS_DIR)/$(1) | $(PDFINFO_IGNORE_CMD) > $(TEST_EXPORTS_DIR)/$(1).expected.info && \
-		pdfinfo $(TEST_EXPORTS_DIR)/$(1) | $(PDFINFO_IGNORE_CMD) > $(TEST_EXPORTS_DIR)/$(1).actual.info && \
-		diff $(TEST_EXPORTS_DIR)/$(1).expected.info $(TEST_EXPORTS_DIR)/$(1).actual.info"
-	magick compare -verbose -metric SSIM \
-	  \( -density 300 $(EXAMPLE_EXPORTS_DIR)/$(1) -background white -alpha remove \) \
-	  \( -density 300 $(TEST_EXPORTS_DIR)/$(1) -background white -alpha remove \) \
-	  null: 2>&1 \
-		| tee /dev/stderr \
-		| grep -i "all" \
-		| awk 'BEGIN { found=0 } { found=1; val=$$2 } END { \
-			if (!found) exit 1; \
-	    if (val > 0.5) { exit (val >= 0.999 ? 0 : 1) } \
-	    else { exit (val <= 0.001 ? 0 : 1) } \
-		}'
-endef
-
 test-exports: download
-	rm -vrf $(TEST_EXPORTS_DIR)
-	mkdir -vp $(TEST_EXPORTS_DIR)
-	cd example-exports && go run examplegen.go ../$(TEST_EXPORTS_DIR)
-	diff $(EXAMPLE_EXPORTS_DIR)/$(TXT_FILE) $(TEST_EXPORTS_DIR)/$(TXT_FILE)
-	$(call compare-pdf,$(PDF_FILE))
-	$(call compare-pdf,$(PDF_FILE_WKHTML))
+	bash scripts/test-exports.sh
 
 clean:
 	rm -vrf \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ cat "messages-export/Novak Djokovic/iMessage;-;+3815555555555.txt"
 ![Example PDF Export](example-exports/example-pdf-screenshot.png)
 
 ## Prerequisites
-- [weasyprint](https://weasyprint.org/) (only needed for PDF export)
+- [WeasyPrint](https://weasyprint.org/) (only needed for PDF export)
 ```
 brew install weasyprint
 ```

--- a/scripts/test-exports.sh
+++ b/scripts/test-exports.sh
@@ -6,7 +6,6 @@ EXAMPLE_EXPORTS_DIR="example-exports/$OS"
 TEST_EXPORTS_DIR="test-exports"
 EXAMPLE_EXPORT_FILE='Novak Djokovic/iMessage;-;+3815555555555'
 PDFINFO_IGNORE_PATTERN='Creator|CreationDate|File size|Producer'
-MAGICK_MAJOR=$(compare --version | awk 'NR==1 { split($3, v, "."); print v[1] }')
 
 TMPDIR_SCRIPT=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_SCRIPT"' EXIT
@@ -27,12 +26,14 @@ compare_pdf() {
     # not installed).
     (
         set +o pipefail
-        compare -verbose -metric SSIM -density 300 -background white -alpha remove \
+        magick compare -verbose -metric SSIM -density 300 -background white -alpha remove \
             "$expected" "$actual" null: 2>&1 \
             | tee /dev/stderr \
             | grep -i "all" \
-            | awk -v major="$MAGICK_MAJOR" \
-                'BEGIN { found=0 } { found=1; val=$2 } END { if (!found) exit 1; exit (major+0 >= 7 ? val <= 0.001 : val >= 0.999) ? 0 : 1 }'
+            | awk 'BEGIN { found=0 } { found=1; val=$2 } END { \
+                if (!found) exit 1; \
+                exit (val <= 0.001) ? 0 : 1 \
+            }'
     )
 }
 

--- a/scripts/test-exports.sh
+++ b/scripts/test-exports.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+OS=$(uname -s)
+EXAMPLE_EXPORTS_DIR="example-exports/$OS"
+TEST_EXPORTS_DIR="test-exports"
+EXAMPLE_EXPORT_FILE='Novak Djokovic/iMessage;-;+3815555555555'
+PDFINFO_IGNORE_PATTERN='Creator|CreationDate|File size|Producer'
+MAGICK_MAJOR=$(compare --version | awk 'NR==1 { split($3, v, "."); print v[1] }')
+
+TMPDIR_SCRIPT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_SCRIPT"' EXIT
+
+compare_pdf() {
+    local file="$1"
+    local expected="$EXAMPLE_EXPORTS_DIR/$file"
+    local actual="$TEST_EXPORTS_DIR/$file"
+
+    echo "==> Comparing PDF metadata: $file"
+    pdfinfo "$expected" | grep -Ev "$PDFINFO_IGNORE_PATTERN" > "$TMPDIR_SCRIPT/pdfinfo-expected"
+    pdfinfo "$actual" | grep -Ev "$PDFINFO_IGNORE_PATTERN" > "$TMPDIR_SCRIPT/pdfinfo-actual"
+    diff "$TMPDIR_SCRIPT/pdfinfo-expected" "$TMPDIR_SCRIPT/pdfinfo-actual"
+
+    echo "==> Comparing PDF visually: $file"
+    # magick compare exits 1 even for valid comparisons (any pixel difference), so pipefail is
+    # disabled for this pipeline. The awk explicitly fails if no SSIM output is produced (e.g. gs
+    # not installed).
+    (
+        set +o pipefail
+        compare -verbose -metric SSIM -density 300 -background white -alpha remove \
+            "$expected" "$actual" null: 2>&1 \
+            | tee /dev/stderr \
+            | grep -i "all" \
+            | awk -v major="$MAGICK_MAJOR" \
+                'BEGIN { found=0 } { found=1; val=$2 } END { if (!found) exit 1; exit (major+0 >= 7 ? val <= 0.001 : val >= 0.999) ? 0 : 1 }'
+    )
+}
+
+echo "==> Generating test exports"
+rm -rf "$TEST_EXPORTS_DIR"
+mkdir -p "$TEST_EXPORTS_DIR"
+(cd example-exports && go run examplegen.go "../$TEST_EXPORTS_DIR")
+
+echo "==> Comparing text export"
+diff "$EXAMPLE_EXPORTS_DIR/messages-export/$EXAMPLE_EXPORT_FILE.txt" \
+     "$TEST_EXPORTS_DIR/messages-export/$EXAMPLE_EXPORT_FILE.txt"
+
+compare_pdf "messages-export-pdf/$EXAMPLE_EXPORT_FILE.pdf"
+compare_pdf "messages-export-wkhtmltopdf/$EXAMPLE_EXPORT_FILE.pdf"
+
+echo "==> All exports match"


### PR DESCRIPTION
**What is changing**: Use ImageMagick to compare test PDF exports instead of diff-pdf.

**Why this change is being made**: HEIC to JPEG conversion is very difficult to make pixel-perfect deterministic across different machines and platforms. ImageMagick has similarity metrics allowing us to set a threshold for similarity rather than failing when exports are no pixel-identical to reference exports.

**Related issue(s)**: N/A

**Follow-up changes needed**: None

**Is the change completely covered by unit tests? If not, why not?**: No, this is part of the testing infra.
